### PR TITLE
Add resource: GOV.UK Home Education

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-![Resources](https://img.shields.io/badge/resources-70-blue)
+![Resources](https://img.shields.io/badge/resources-71-blue)
 ![Sections](https://img.shields.io/badge/sections-11-purple)
 [![Changelog](https://img.shields.io/badge/changelog-v1.0.0-lightgrey.svg)](CHANGELOG.md)
 
@@ -35,7 +35,7 @@ This is a curation list, not a code library. Every entry links out to a tool, ch
 | 💰 | [Scholarships & Financial Aid](#scholarships--financial-aid) | 4 |
 | 🎯 | [University & Career Prep](#university--career-prep) | 6 |
 | 🎤 | [Debate & Public Speaking](#debate--public-speaking) | 4 |
-| 🏠 | [Homeschooling](#homeschooling) | 5 |
+| 🏠 | [Homeschooling](#homeschooling) | 6 |
 | 🔓 | [FOSS Picks](#foss-picks) | 11 |
 | 🎙️ | [Blogs, Newsletters & Podcasts](#blogs-newsletters--podcasts) | 10 |
 | 📖 | [Books We Trust](#books-we-trust) | 5 |
@@ -124,6 +124,7 @@ Curriculum, planning, record-keeping, and the logistics of learning at home.
 - **[Ambleside Online](https://amblesideonline.org)** - Free, complete Charlotte Mason curriculum with book lists and schedules (free).
 - **[Easy Peasy All-in-One Homeschool](https://allinonehomeschool.com)** - Free, complete K-12 curriculum you can follow day by day (free).
 - **[Freedom Homeschooling](https://freedomhomeschooling.com)** - Free directory of free homeschool curricula sorted by subject (free).
+- **[GOV.UK Home Education](https://www.gov.uk/home-education)** - Official UK government guidance on home education rights.
 - **[HSLDA](https://hslda.org/legal/)** - US homeschool laws, record-keeping, and testing requirements by state (free).
 - **[The Homeschool Mom](https://www.thehomeschoolmom.com)** - Free planners, record-keeping printables, and getting-started guides (free).
 


### PR DESCRIPTION
## Resource added
- **[GOV.UK Home Education](https://www.gov.uk/home-education)** - Official UK government guidance on home education rights.

## Why is it useful for students?
GOV.UK provides the official UK government's authoritative guidance on home education rights, responsibilities, and procedures for families in England and Wales.

## Verification criteria
- **Quality**: Official UK government website (GOV.UK)
- **Price**: free
- **Not duplicate**: ✅

Closes #81 (partial)