### PR TITLE
Add a pricing-tag correction issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/pricing_correction.yml
+++ b/.github/ISSUE_TEMPLATE/pricing_correction.yml
@@ -1,0 +1,50 @@
+name: Report a wrong pricing tag
+description: An entry's free / freemium / paid / open source tag is out of date or wrong
+labels: ["pricing-review", "quality"]
+body:
+  - type: input
+    id: entry
+    attributes:
+      label: Entry name
+      description: The exact name of the entry as it appears in the README
+    validations:
+      required: true
+  - type: input
+    id: section
+    attributes:
+      label: Section
+      description: Which section of the README it's in
+    validations:
+      required: true
+  - type: dropdown
+    id: current_tag
+    attributes:
+      label: Current tag
+      description: What the entry says today
+      options:
+        - free
+        - freemium
+        - paid
+        - open source
+        - no tag at all
+    validations:
+      required: true
+  - type: dropdown
+    id: correct_tag
+    attributes:
+      label: Correct tag
+      description: What it should say instead
+      options:
+        - free
+        - freemium
+        - paid
+        - open source
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: How do you know?
+      description: A link to the pricing page, or what you saw when you signed up. Screenshots are fine.
+    validations:
+      required: true


### PR DESCRIPTION
Closes #131.

## Resource

Not a resource PR. This adds a new issue form, so the resource fields below are N/A.

Link: N/A

Why it helps students: N/A

## What this adds

`.github/ISSUE_TEMPLATE/pricing_correction.yml` - a short form for reporting a stale or wrong pricing tag outside the monthly `pricing-review.yml` cycle. Asks for entry name, section, current tag, correct tag, and evidence.

Labels are set to `pricing-review` and `quality`, both of which exist in this repo (checked with `gh label list`), so the form will not file unlabelled issues.

## Checklist

- [x] Added in the correct section, in alphabetical order (case-insensitive) - N/A, no README entry
- [x] Follows the entry format from [CONTRIBUTING.md](../CONTRIBUTING.md) - N/A, no README entry
- [x] Meets the [Quality Standards](../README.md#quality-standards) - N/A, no README entry
- [x] Not a duplicate of an existing entry in the same section - N/A; checked the four existing templates, none covers pricing corrections

`scripts/check-list-format.mjs` still passes; README is untouched.
