### PR TITLE
Fix pre-commit JSON export drift check

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,8 +2,8 @@
 # Opt-in local pre-commit check. Enable once with:
 #   git config core.hooksPath .githooks
 #
-# Mirrors the CI lint job (.github/workflows/lint.yml) so format/count
-# problems surface before you push instead of after CI fails on your PR.
+# Mirrors the CI lint job (.github/workflows/lint.yml) so format, count,
+# and JSON export drift surface before CI fails on your PR.
 # Only runs when README.md or CONTRIBUTING.md is actually staged, so it
 # stays out of the way for unrelated commits.
 
@@ -11,7 +11,8 @@ staged=$(git diff --cached --name-only)
 
 echo "$staged" | grep -qE '^(README\.md|CONTRIBUTING\.md)$' || exit 0
 
-echo "pre-commit: README.md/CONTRIBUTING.md staged, running list-format checks..."
+echo "pre-commit: README.md/CONTRIBUTING.md staged, running format, count, and JSON export checks..."
 
 node scripts/check-list-format.mjs || exit 1
 node scripts/update-counts.mjs --check || exit 1
+node scripts/export-json.mjs --check || exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ A committed, opt-in pre-commit hook mirrors the CI lint job. Enable it once per 
 git config core.hooksPath .githooks
 ```
 
-After that, committing with README.md or CONTRIBUTING.md staged runs `scripts/check-list-format.mjs` and `scripts/update-counts.mjs --check` automatically, so format or count problems surface before you push instead of after CI fails on your PR. It's entirely optional and doesn't install anything beyond what's already in this repo; see `.githooks/pre-commit` for the script itself.
+After that, committing with README.md or CONTRIBUTING.md staged runs `scripts/check-list-format.mjs`, `scripts/update-counts.mjs --check`, and `scripts/export-json.mjs --check` automatically, so format, count, or generated JSON drift surfaces before you push instead of after CI fails on your PR. It's entirely optional and doesn't install anything beyond what's already in this repo; see `.githooks/pre-commit` for the script itself.
 
 ---
 

--- a/data/resources.json
+++ b/data/resources.json
@@ -712,6 +712,22 @@
     "subsection": null
   },
   {
+    "name": "Peak: Secrets from the New Science of Expertise",
+    "url": "https://peakthebook.com/",
+    "description": "Learn deliberate practice for developing expertise",
+    "pricing": "paid",
+    "section": "Books We Trust",
+    "subsection": null
+  },
+  {
+    "name": "The 7 Habits of Highly Effective People",
+    "url": "https://www.franklincovey.com/books/the-7-habits-of-highly-effective-people/",
+    "description": "Build habits for effective goals and priorities",
+    "pricing": "paid",
+    "section": "Books We Trust",
+    "subsection": null
+  },
+  {
     "name": "Ali Abdaal",
     "url": "https://aliabdaal.com",
     "description": "Evidence-based study and productivity guides",


### PR DESCRIPTION
## Summary

- Add the missing `export-json.mjs --check` gate to the opt-in pre-commit hook.
- Update the hook status text and contributor documentation so all three failing CI lint checks are explicit.
- Regenerate `data/resources.json` for the two book entries added by #155, which had left current `main` out of sync before this hook could pass.

Fixes #153.

## Validation

- RED: with a valid README description drift staged, the old hook exited 0 while `export-json.mjs --check` exited 1.
- GREEN: the updated hook rejects that same staged drift at the JSON export check, then passes after the generated file is synchronized.
- `node --test scripts/*.test.mjs` — 51 passed.
- `make lint` — passed, including the JSON export check.
- `sh -n` and ShellCheck for `.githooks/pre-commit` — passed.
- Codespell, markdownlint-cli2, and `git diff --check` — passed.

## Generated-data note

The JSON hunk contains only the two resources already present in current `README.md`: `Peak: Secrets from the New Science of Expertise` and `The 7 Habits of Highly Effective People`. There are no removals or unrelated generated changes.
