### PR TITLE
Add Jitsi Meet to FOSS Picks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A curated list of the best software, tools, textbooks, channels, and resources f
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-![Resources](https://img.shields.io/badge/resources-177-blue)
+![Resources](https://img.shields.io/badge/resources-178-blue)
 ![Sections](https://img.shields.io/badge/sections-13-purple)
 [![Changelog](https://img.shields.io/badge/changelog-v2.0.0-lightgrey.svg)](CHANGELOG.md)
 
@@ -40,7 +40,7 @@ This list covers life around school: discounts, money, career prep, and wellbein
 | 🔧  | [Vocational & Alternative Paths](#vocational--alternative-paths)               |     9     |
 | 🎤  | [Debate & Public Speaking](#debate--public-speaking)                           |    10     |
 | 🏠  | [Homeschooling](#homeschooling)                                                |    14     |
-| 🔓  | [FOSS Picks](#foss-picks)                                                      |    16     |
+| 🔓  | [FOSS Picks](#foss-picks)                                                      |    17     |
 | 🎧  | [Blogs, Newsletters & Podcasts](#blogs-newsletters--podcasts)                  |    11     |
 | 📖  | [Books We Trust](#books-we-trust)                                              |    11     |
 | 💡  | [Guides & How-Tos](#guides--how-tos)                                           |    10     |
@@ -270,6 +270,7 @@ Fully free and open-source tools worth installing.
 - **[GIMP](https://www.gimp.org)** - Free, open image editor (free).
 - **[Habitica](https://habitica.com)** - Free, open-source habit and task tracker with RPG-style gamification (free).
 - **[Inkscape](https://inkscape.org)** - Free, open vector graphics editor (free).
+- **[Jitsi Meet](https://meet.jit.si)** - Free, open-source video calls with no account required (free).
 - **[Joplin](https://joplinapp.org)** - Free, open note-taking app with markdown and sync (free).
 - **[KeePassXC](https://keepassxc.org)** - Free, open-source, offline password manager (free).
 - **[Krita](https://krita.org)** - Free, open painting and illustration app (free).


### PR DESCRIPTION
Add Jitsi Meet to FOSS Picks

FOSS Picks had no video-calling entry despite it being one of the most
common needs for study groups and remote office hours. Closes #213.
