### PR TITLE
Add resource: PracHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A curated list of the best software, tools, textbooks, channels, and resources f
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-![Resources](https://img.shields.io/badge/resources-179-blue)
+![Resources](https://img.shields.io/badge/resources-180-blue)
 ![Sections](https://img.shields.io/badge/sections-13-purple)
 [![Changelog](https://img.shields.io/badge/changelog-v2.0.0-lightgrey.svg)](CHANGELOG.md)
 
@@ -36,7 +36,7 @@ This list covers life around school: discounts, money, career prep, and wellbein
 | 🎓  | [Student Discounts & Free Access](#student-discounts--free-access)             |    13     |
 | 💰  | [Scholarships & Financial Aid](#scholarships--financial-aid)                   |    14     |
 | 💵  | [Financial Literacy & Money Management](#financial-literacy--money-management) |    12     |
-| 🎯  | [University & Career Prep](#university--career-prep)                           |    29     |
+| 🎯  | [University & Career Prep](#university--career-prep)                           |    30     |
 | 🔧  | [Vocational & Alternative Paths](#vocational--alternative-paths)               |     9     |
 | 🎤  | [Debate & Public Speaking](#debate--public-speaking)                           |    10     |
 | 🏠  | [Homeschooling](#homeschooling)                                                |    14     |
@@ -144,6 +144,7 @@ What comes after exams: applications, resumes, interviews, and time away from th
 - **[Exponent](https://www.tryexponent.com/practice)** - Free peer and AI mock interviews for tech and PM roles (freemium).
 - **[Novoresume](https://novoresume.com)** - Free, ATS-friendly resume builder with student-focused templates (freemium).
 - **[OUAC](https://www.ouac.on.ca)** - The official application portal for undergraduate admission to Ontario universities (free).
+- **[PracHub](https://prachub.com/interview-guide)** - Browse interview guides and questions by company, role, and topic (free).
 - **[The Muse](https://www.themuse.com/advice/cover-letter)** - Free cover letter guides, templates, and examples (free).
 - **[Transferology](https://www.transferology.com)** - Free tool to check how your course credits transfer between US colleges (free).
 - **[UAC](https://www.uac.edu.au)** - The official university application portal for New South Wales and the ACT, Australia (free).

--- a/data/resources.json
+++ b/data/resources.json
@@ -368,6 +368,14 @@
     "subsection": "Applications & Resumes"
   },
   {
+    "name": "PracHub",
+    "url": "https://prachub.com/interview-guide",
+    "description": "Browse interview guides and questions by company, role, and topic",
+    "pricing": "free",
+    "section": "University & Career Prep",
+    "subsection": "Applications & Resumes"
+  },
+  {
     "name": "The Muse",
     "url": "https://www.themuse.com/advice/cover-letter",
     "description": "Free cover letter guides, templates, and examples",


### PR DESCRIPTION
## Summary

- Add PracHub to University & Career Prep in alphabetical order.
- Regenerate the README counts and `data/resources.json`.

PracHub gives students free technical interview guides and candidate-reported questions that can be
filtered by company, role, and topic. Disclosure: I am the founder of PracHub. This PR follows the
maintainer's independent review and invitation in
https://github.com/StudentSuite/awesome-student-resources/discussions/218.

## Checks

- `node scripts/check-list-format.mjs`
- `node scripts/update-counts.mjs --check`
- `node scripts/export-json.mjs --check`
- `node --test scripts/*.test.mjs` (51 passed)
