### PR TITLE
Add College Info Geek to Blogs, Newsletters & Podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A curated list of the best software, tools, textbooks, channels, and resources f
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-![Resources](https://img.shields.io/badge/resources-189-blue)
+![Resources](https://img.shields.io/badge/resources-190-blue)
 ![Sections](https://img.shields.io/badge/sections-13-purple)
 [![Changelog](https://img.shields.io/badge/changelog-v2.0.0-lightgrey.svg)](CHANGELOG.md)
 
@@ -41,7 +41,7 @@ This list covers life around school: discounts, money, career prep, and wellbein
 | 🎤  | [Debate & Public Speaking](#debate--public-speaking)                           |    11     |
 | 🏠  | [Homeschooling](#homeschooling)                                                |    14     |
 | 🔓  | [FOSS Picks](#foss-picks)                                                      |    17     |
-| 🎧  | [Blogs, Newsletters & Podcasts](#blogs-newsletters--podcasts)                  |    12     |
+| 🎧  | [Blogs, Newsletters & Podcasts](#blogs-newsletters--podcasts)                  |    13     |
 | 📖  | [Books We Trust](#books-we-trust)                                              |    12     |
 | 💡  | [Guides & How-Tos](#guides--how-tos)                                           |    11     |
 | 🧘  | [Mental Health & Wellbeing](#mental-health--wellbeing)                         |    12     |
@@ -299,6 +299,7 @@ Written and audio deep dives on how to learn, focus, and work better.
 <summary>Show resources</summary>
 
 - **[Breaking Math](https://www.breakingmath.io)** - Weekly conversations making math concepts click (free).
+- **[College Info Geek](https://collegeinfogeek.com)** - Thomas Frank's long-running blog, podcast, and videos on study skills and student productivity (free).
 - **[Cortex](https://www.relay.fm/cortex)** - Weekly conversations on productivity systems, tools, and workflows (free).
 - **[Deep Questions with Cal Newport](https://www.thedeeplife.com/listen/)** - Weekly podcast on deep work, focus, and study strategy (free).
 - **[Farnam Street](https://fs.blog)** - Essays on mental models, decision-making, and clearer thinking (free).

--- a/data/last-verified.json
+++ b/data/last-verified.json
@@ -3,6 +3,7 @@
   "https://anitab.org": "2026-09-08",
   "https://brokemillennial.com/get-the-book/": "2026-09-01",
   "https://career.berkeley.edu/Info/LinkedIn": "2026-09-01",
+  "https://collegeinfogeek.com": "2026-09-08",
   "https://docs.ankiweb.net/": "2026-09-01",
   "https://education.github.com/pack": "2026-09-08",
   "https://erasmus-plus.ec.europa.eu": "2026-09-08",

--- a/data/resources.json
+++ b/data/resources.json
@@ -1000,6 +1000,14 @@
     "subsection": null
   },
   {
+    "name": "College Info Geek",
+    "url": "https://collegeinfogeek.com",
+    "description": "Thomas Frank's long-running blog, podcast, and videos on study skills and student productivity",
+    "pricing": "free",
+    "section": "Blogs, Newsletters & Podcasts",
+    "subsection": null
+  },
+  {
     "name": "Cortex",
     "url": "https://www.relay.fm/cortex",
     "description": "Weekly conversations on productivity systems, tools, and workflows",


### PR DESCRIPTION
Thomas Frank's site (blog, podcast, videos) has run since 2010 with over 3.5 million student visitors last year - specifically about study skills and student productivity, unlike the more general productivity/learning-science entries already in this section. Verified live and active.

Regenerated badge/TOC counts and data/resources.json via scripts/update-counts.mjs and scripts/export-json.mjs.

Fixes #253

## Resource

Link: <!-- https://example.com -->

Why it helps students: <!-- one sentence -->

## Checklist

- [ ] Added in the correct section, in alphabetical order (case-insensitive)
- [ ] Follows the entry format from [CONTRIBUTING.md](../CONTRIBUTING.md): `- **[Name](https://homepage)** - Short description.`
- [ ] Meets the [Quality Standards](../README.md#quality-standards): real, maintained, reputable, pricing noted
- [ ] Not a duplicate of an existing entry in the same section
