### PR TITLE
Verify resource: Study Together

### DIFF
--- a/data/last-verified.json
+++ b/data/last-verified.json
@@ -54,6 +54,7 @@
   "https://www.simonandschuster.com/books/The-Art-of-Learning/Josh-Waitzkin/9780743277464": "2026-09-08",
   "https://www.studentbeans.com": "2026-09-01",
   "https://www.studentminds.org.uk/advice-and-info/feeling-homesick-at-university/": "2026-09-08",
+  "https://studytogether.com": "2026-09-11",
   "https://www.themuse.com/advice/cover-letters": "2026-09-01",
   "https://www.thescholarshiphub.org.uk": "2026-09-08",
   "https://www.thetrevorproject.org": "2026-09-08",


### PR DESCRIPTION
## Resource

Link: https://studytogether.com

Closes #273

## Verification

Checked on 2026-09-11:

- The homepage responds successfully (HTTP 200).
- The live site describes active 24/7 study rooms and links to the app and Discord community.
- The site identifies the service as free and offers a free account; the existing `(free)` tag remains accurate.
- The live Study Together API and Discord invite both respond successfully (HTTP 200).

Recorded `https://studytogether.com`: `2026-09-11` in `data/last-verified.json`.

## Testing

- JSON parsed and the verification date was asserted with Node.
- `node scripts/check-verification-age.mjs` no longer reports Study Together as stale.
- `git diff --check`