### PR TITLE
Verify: Canva for Education (#261)

### DIFF
--- a/data/last-verified.json
+++ b/data/last-verified.json
@@ -26,6 +26,7 @@
   "https://www.adobe.com/creativecloud/buy/students.html": "2026-09-11",
   "https://www.amazon.com/joinstudent": "2026-09-11",
   "https://www.apprenticeship.gov": "2026-09-08",
+  "https://www.canva.com/education/": "2026-09-11",
   "https://www.collegevine.com": "2026-09-11",
   "https://www.commonapp.org": "2026-09-08",
   "https://www.coursera.org/learn/learning-how-to-learn": "2026-09-01",


### PR DESCRIPTION
## Resource

Link: https://www.canva.com/education/

Why it helps students: Canva Education provides free, classroom-ready design and collaboration tools for verified K–12 students and teachers.

## Verification

Verified on 2026-09-11: the official page is live, Canva describes Education as 100% free for eligible K–12 educators and students, and the offering is actively maintained.

Closes #261

## Checklist

- [x] Added the verification date to `data/last-verified.json`
- [x] Confirmed the link works
- [x] Confirmed the resource is maintained and reputable
- [x] Confirmed the pricing tag remains accurate