### PR TITLE
Verify: Toastmasters International

### DIFF
--- a/data/last-verified.json
+++ b/data/last-verified.json
@@ -61,6 +61,7 @@
   "https://www.themuse.com/advice/cover-letters": "2026-09-01",
   "https://www.thescholarshiphub.org.uk": "2026-09-08",
   "https://www.thetrevorproject.org": "2026-09-08",
+  "https://www.toastmasters.org": "2026-09-11",
   "https://www.ucas.com": "2026-09-08",
   "https://www.upwork.com": "2026-09-08",
   "https://www.ynab.com": "2026-09-11",


### PR DESCRIPTION
## Verification

Closes #266.

Verified on 2026-09-11:

- [Toastmasters International](https://www.toastmasters.org) returns HTTP 200 and identifies an active nonprofit organization with clubs and public-speaking education.
- The [official education programs page](https://www.toastmasters.org/en-us/education) documents current Pathways and Speechcraft programs.
- The [official membership FAQ](https://www.toastmasters.org/footer/faq/Membership%20Dues), updated July 2026, lists paid membership dues and a new-member fee, so the existing `freemium` tag remains accurate.

Recorded the verification date in `data/last-verified.json`; no README entry needed changing.