### PR TITLE
docs: verify SkillsFuture Singapore (#265)

### DIFF
--- a/data/last-verified.json
+++ b/data/last-verified.json
@@ -55,6 +55,7 @@
   "https://www.reddit.com/r/igcse/": "2026-09-08",
   "https://www.reddit.com/r/SAT/": "2026-09-08",
   "https://www.simonandschuster.com/books/The-Art-of-Learning/Josh-Waitzkin/9780743277464": "2026-09-08",
+  "https://www.skillsfuture.gov.sg/": "2026-09-11",
   "https://www.studentbeans.com": "2026-09-01",
   "https://www.studentminds.org.uk/advice-and-info/feeling-homesick-at-university/": "2026-09-08",
   "https://studytogether.com": "2026-09-11",


### PR DESCRIPTION
## Resource

Link: https://www.skillsfuture.gov.sg/

Why it helps students: SkillsFuture Singapore is Singapore's official portal for skills-training credits and course subsidies.

## Verification

- The official homepage returned HTTP 200 on 2026-09-11 and is actively serving current SkillsFuture programmes.
- The official Individuals page still describes SkillsFuture Credit and training subsidies.
- The public portal remains free to access; the entry does not claim that every linked course is free.
- Recorded the verification date in `data/last-verified.json`.

## Checklist

- [x] Added in the correct section, in alphabetical order (case-insensitive)
- [x] Follows the entry format from [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Meets the [Quality Standards](../README.md#quality-standards)
- [x] Not a duplicate of an existing entry in the same section

Closes #265